### PR TITLE
Removed 2 unnecessary spaces

### DIFF
--- a/src/config/yubikey.php
+++ b/src/config/yubikey.php
@@ -10,8 +10,8 @@ return array(
 
 	'URL_LIST' => array(
 						'api.yubico.com/wsapi/2.0/verify',
-						'api2.yubico.com/wsapi/2.0/verify', 
-						'api3.yubico.com/wsapi/2.0/verify', 
+						'api2.yubico.com/wsapi/2.0/verify',
+						'api3.yubico.com/wsapi/2.0/verify',
 						'api4.yubico.com/wsapi/2.0/verify',
 						'api5.yubico.com/wsapi/2.0/verify',
 						),


### PR DESCRIPTION
2 of the 5 yubico api urls have a space after the comma, it will show up in some editors.
