### PR TITLE
Force HTTPS protocol

### DIFF
--- a/src/Yubikey.php
+++ b/src/Yubikey.php
@@ -88,16 +88,15 @@ class Yubikey
      * Constructor
      *
      * Sets up the object
-     * @param    array $config The client configuration
      * @access public
      * @throws \Exception
      */
-    public function __construct($config = array())
+    public function __construct()
     {
-        $this->_id = (isset($config['id']) && !empty($config['id'])) ? $id : config('yubikey.CLIENT_ID');
-        $this->_key = base64_decode((isset($config['key']) && !empty($config['key'])) ? $key : config('yubikey.SECRET_KEY'));
-        $this->_https = (isset($config['https'])) ? $config['https'] : 0;
-        $this->_httpsverify = (isset($config['httpsverify'])) ? $config['httpsverify'] : 1;
+        $this->_id = config('yubikey.CLIENT_ID');
+        $this->_key = base64_decode(config('yubikey.SECRET_KEY'));
+        $this->_https = true;
+        $this->_httpsverify = config('yubikey.HTTPS_VERIFY');
 
         if (!$this->_id)  throw new \Exception('Check your CLIENT_ID');
         if (!$this->_key) throw new \Exception('Check your SECRET_KEY');

--- a/src/Yubikey.php
+++ b/src/Yubikey.php
@@ -319,7 +319,11 @@ class Yubikey
             $handle = curl_init($query);
             curl_setopt($handle, CURLOPT_USERAGENT, config('yubikey.USER_AGENT'));
             curl_setopt($handle, CURLOPT_RETURNTRANSFER, 1);
-            if (!$this->_httpsverify)  curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, 0);
+            if (!$this->_httpsverify) {
+                curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, 0);
+            } else {
+                curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, true);
+            }
             curl_setopt($handle, CURLOPT_FAILONERROR, true);
 
             /*
@@ -327,7 +331,13 @@ class Yubikey
              * in case the validation server fails to follow it.
              * */
             if ($timeout)  curl_setopt($handle, CURLOPT_TIMEOUT, $timeout);
+
+            if (config('yubikey.CAINFO_LOCATION')) {
+                curl_setopt($handle, CURLOPT_CAINFO, config('yubikey.CAINFO_LOCATION'));
+            }
+
             curl_multi_add_handle($mh, $handle);
+
             $ch[(int)$handle] = $handle;
         }
 

--- a/src/config/yubikey.php
+++ b/src/config/yubikey.php
@@ -6,14 +6,15 @@
  * */
 
 return [
-    'CLIENT_ID' => '',
-    'SECRET_KEY' => '',
-    'URL_LIST' => [
+    'CLIENT_ID'    => '',
+    'SECRET_KEY'   => '',
+    'URL_LIST'     => [
         'api.yubico.com/wsapi/2.0/verify',
         'api2.yubico.com/wsapi/2.0/verify',
         'api3.yubico.com/wsapi/2.0/verify',
         'api4.yubico.com/wsapi/2.0/verify',
         'api5.yubico.com/wsapi/2.0/verify',
     ],
-    'USER_AGENT' => 'Laravel 5',
+    'USER_AGENT'   => 'Laravel 5',
+    'HTTPS_VERIFY' => false,
 ];

--- a/src/config/yubikey.php
+++ b/src/config/yubikey.php
@@ -6,15 +6,16 @@
  * */
 
 return [
-    'CLIENT_ID'    => '',
-    'SECRET_KEY'   => '',
-    'URL_LIST'     => [
+    'CLIENT_ID'       => '',
+    'SECRET_KEY'      => '',
+    'URL_LIST'        => [
         'api.yubico.com/wsapi/2.0/verify',
         'api2.yubico.com/wsapi/2.0/verify',
         'api3.yubico.com/wsapi/2.0/verify',
         'api4.yubico.com/wsapi/2.0/verify',
         'api5.yubico.com/wsapi/2.0/verify',
     ],
-    'USER_AGENT'   => 'Laravel 5',
-    'HTTPS_VERIFY' => false,
+    'USER_AGENT'      => 'Laravel 5',
+    'HTTPS_VERIFY'    => true,
+    'CAINFO_LOCATION' => '',
 ];


### PR DESCRIPTION
As [the blog post from yubico](https://status.yubico.com/2018/11/26/deprecating-yubicloud-v1-protocol-plain-text-requests-and-old-tls-versions/) HTTPS protocol is now required.

I also made some minor change in order to let the possibility in the config file to verify HTTPS.